### PR TITLE
Fix anchor target attributes on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@ title: Mustafa Steven Ascha
 
 <p> I'm <strong>Mustafa Ascha</strong>: quantitative health scientist, guitarist, coder, linux user, philosophy enthusiast, research ethicist, aspiring functional programmer, and generally curious person.</p>
 
-<p>To see a more comprehensive list of my work, <a href="http://mustafa.fyi/assets/Ascha-CV.pdf", target = "_blank"> check out my CV,</a> <a href="http://github.com/mustafaascha", target="_blank"> github,</a> <a href="https://soundcloud.com/mustafa-ascha", target="_blank"> or soundcloud.</a> </p>
+<p>To see a more comprehensive list of my work, <a href="http://mustafa.fyi/assets/Ascha-CV.pdf" target="_blank"> check out my CV,</a> <a href="http://github.com/mustafaascha" target="_blank"> github,</a> <a href="https://soundcloud.com/mustafa-ascha" target="_blank"> or soundcloud.</a> </p>
 
-<p>If you have similar interests, comments, questions, or just want to chat, <a href="mailto:mustafa.ascha@gmail.com", target = "_blank"> feel free to contact me</a>.</p>
+<p>If you have similar interests, comments, questions, or just want to chat, <a href="mailto:mustafa.ascha@gmail.com" target="_blank"> feel free to contact me</a>.</p>
 
 
 


### PR DESCRIPTION
## Summary
- fix malformed comma-separated anchor `target` attributes on the homepage so external links open correctly

## Testing
- `python - <<'PY'
import re, pathlib
text=pathlib.Path('index.html').read_text()
print('Found invalid anchor attributes' if re.search(r',\s*target', text) else 'No invalid anchor attributes found')
PY` (No invalid anchor attributes found)
- `jekyll build` (command not found)
- `gem install jekyll` (403 Forbidden)
- `sudo apt-get update` (403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68ae87622e288332898b8e845f92a007