### PR TITLE
Fix capitalization for Linux in about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ title: Mustafa Steven Ascha
 
 <h2>About me</h2>
 
-<p> I'm <strong>Mustafa Ascha</strong>: quantitative health scientist, guitarist, coder, linux user, philosophy enthusiast, research ethicist, aspiring functional programmer, and generally curious person.</p>
+<p> I'm <strong>Mustafa Ascha</strong>: quantitative health scientist, guitarist, coder, Linux user, philosophy enthusiast, research ethicist, aspiring functional programmer, and generally curious person.</p>
 
 <p>To see a more comprehensive list of my work, <a href="http://mustafa.fyi/assets/Ascha-CV.pdf", target = "_blank"> check out my CV,</a> <a href="http://github.com/mustafaascha", target="_blank"> github,</a> <a href="https://soundcloud.com/mustafa-ascha", target="_blank"> or soundcloud.</a> </p>
 


### PR DESCRIPTION
## Summary
- Capitalize "Linux" in the about paragraph for correct proper noun usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8852620c8332b2aaac01d3d3c1d9