### PR TITLE
Reset blockquote and quote defaults

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -29,6 +29,12 @@ ol, ul {
 }
 
 blockquote, q {
+  quotes: none;
+}
+
+blockquote:before, blockquote:after, q:before, q:after {
+  content: '';
+  content: none;
 }
 
 table {


### PR DESCRIPTION
## Summary
- stop browsers from inserting automatic quotation marks for `blockquote` and `q`

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ae8887e734833289613ee21d657000